### PR TITLE
Add DEV to Links

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -45,6 +45,10 @@ module.exports = {
             link: 'https://github.com/vitejs/awesome-vite'
           },
           {
+            text: 'DEV Community',
+            link: 'https://dev.to/t/vite'
+          },
+          {
             text: 'Rollup Plugins Compat',
             link: 'https://vite-rollup-plugins.patak.dev/'
           },


### PR DESCRIPTION
This adds a link to https://dev.to/t/vite.

Now that y'all have posted to this tag, it seems to make sense to point people there as a resource, because other folks have also posted there. We have also added `vite` as a supported tag, so it will show up as the canonical place for vite content. If anybody wants to also moderate the tag, reach out to us at yo@dev.to to get started.

This follows a similar pattern to how other projects such as Vue and React link to their tags with this same anchor text.